### PR TITLE
Fix license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ python NHET.py
 
 ## 📄 Licencia
 
-Este proyecto está licenciado bajo la Licencia MIT - consulta el archivo [LICENSE]([LICENSE](https://github.com/maicoldlx/nethack-elite-tools/blob/main/License)) para más detalles.
+Este proyecto está licenciado bajo la Licencia MIT - consulta el archivo [License](License) para más detalles.
 
 ## 🙏 Agradecimientos
 


### PR DESCRIPTION
## Summary
- update Spanish README to link to License

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f22ef3e48328bbd11954edf40c45